### PR TITLE
fix to Children - Primary,Secondary and SuperTuxCart

### DIFF
--- a/primary.pm
+++ b/primary.pm
@@ -24,7 +24,6 @@ all
 </preinstall>
 
 <install_package_names>
-celestia-gnome
 gcompris
 gcompris-sound-en
 laby
@@ -45,7 +44,6 @@ marble-plugins
 
 
 <uninstall_package_names>
-celestia-gnome
 gcompris
 gcompris-sound-en
 laby

--- a/secondary.pm
+++ b/secondary.pm
@@ -25,7 +25,6 @@ all
 
 <install_package_names>
 calibre
-celestia-gnome
 dia-gnome
 laby
 lightspeed
@@ -44,7 +43,6 @@ stellarium
 
 <uninstall_package_names>
 calibre
-celestia-gnome
 dia-gnome
 laby
 lightspeed

--- a/supertuxkart.pm
+++ b/supertuxkart.pm
@@ -24,13 +24,13 @@ all
 </preinstall>
 
 <install_package_names>
-
+supertuxkart
+supertuxkart-data
 </install_package_names>
 
 
 <postinstall>
-supertuxkart
-supertuxkart-data
+
 </postinstall>
 
 


### PR DESCRIPTION
Children’s category
- Primary - removed celestia-gnome - pulled from stretch repo, last dev 2008
- Secondary - removed celestia-gnome - ditto
SuperTuxKart - moved code to install section from post-install in pm script
