### PR TITLE
chg'd 3.16.0-4-amd64 to 3.16.0-5-amd64

### DIFF
--- a/kernel_debian_64.pm
+++ b/kernel_debian_64.pm
@@ -24,8 +24,8 @@ Default Debian 4.9 64bit linux kernel
 </preinstall>
 
 <install_package_names>
-linux-image-4.9.0-4-amd64
-linux-headers-4.9.0-4-amd64
+linux-image-4.9.0-5-amd64
+linux-headers-4.9.0-5-amd64
 </install_package_names>
 
 
@@ -35,7 +35,7 @@ linux-headers-4.9.0-4-amd64
 
 
 <uninstall_package_names>
-linux-image-4.9.0-3-amd64
-linux-headers-4.9.0-3-amd64
+linux-image-4.9.0-4-amd64
+linux-headers-4.9.0-4-amd64
 </uninstall_package_names>
 </app>


### PR DESCRIPTION
The default Debian Jessie 3.16 kernel, the 3.16.0-5 update has the kpti patches. [https://tracker.debian.org/news/900500](url)