### PR TITLE
Update handbrake.pm

### DIFF
--- a/handbrake.pm
+++ b/handbrake.pm
@@ -26,6 +26,7 @@ all
 <install_package_names>
 handbrake
 handbrake-cli
+handbrake-gtk
 </install_package_names>
 
 
@@ -37,5 +38,6 @@ handbrake-cli
 <uninstall_package_names>
 handbrake
 handbrake-cli
+handbrake-gtk
 </uninstall_package_names>
 </app>


### PR DESCRIPTION
This script only installs handbrake for command line. To install its GUI counterpart, it must install handbrake-gtk also.