### PR TITLE
fix megasync installer

### DIFF
--- a/megasync.pm
+++ b/megasync.pm
@@ -66,6 +66,7 @@ Megasync
 <screenshot></screenshot>
 
 <preinstall>
+[ ! -f /etc/apt/sources.list.d/megasync.list ] || rm /etc/apt/sources.list.d/megasync.list
 echo "deb https://mega.nz/linux/repo/Debian_12/ ./">/etc/apt/sources.list.d/mxpitemp.list
 curl -sS https://mega.nz/linux/repo/Debian_12/Release.key | gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/megasync.gpg
 apt-get update
@@ -77,11 +78,18 @@ megasync
 
 
 <postinstall>
-rm /etc/apt/sources.list.d/mxpitemp.list
+#[ ! -f /etc/apt/sources.list.d/megasync.list ] || rm /etc/apt/sources.list.d/megasync.list
+[ ! -f /etc/apt/sources.list.d/mxpitemp.list ] || rm /etc/apt/sources.list.d/mxpitemp.list
+[ ! -f /etc/apt/trusted.gpg.d/megasync.gpg   ] || rm /etc/apt/trusted.gpg.d/megasync.gpg
 </postinstall>
 
 
 <uninstall_package_names>
 megasync
 </uninstall_package_names>
+
+
+<postuninstall>
+[ ! -f /etc/apt/sources.list.d/megasync.list ] || rm /etc/apt/sources.list.d/megasync.list
+</postuninstall>
 </app>


### PR DESCRIPTION
megasync create now it's own megasync.list which conflicts during re-install and by this does not remove mxpitemp.list with further trouble. 